### PR TITLE
refactor: Playwright 기반 스크래핑에서 API 직접 호출로 시간표 로딩 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 LABEL maintainer="jandi-band"
 LABEL service="fastapi-scraper"
 
-# 시스템 패키지 설치 (Playwright 의존성)
+# 시스템 패키지 설치
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
@@ -29,12 +29,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
-# Playwright 시스템 의존성을 root로 설치
-RUN playwright install-deps chromium
-
-# 사용자로 전환 후 Playwright 브라우저만 설치
+# 사용자로 전환
 USER scraper
-RUN playwright install chromium
 
 # 소스 코드 복사
 COPY --chown=scraper:scraper . .

--- a/app.py
+++ b/app.py
@@ -1,40 +1,20 @@
-from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import JSONResponse
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, HttpUrl
-from typing import Optional
-from contextlib import asynccontextmanager
-import uvicorn
 import logging
+import uvicorn
 
-from service.scraper import TimetableLoader, get_browser_manager, cleanup_browser_manager
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, HttpUrl
 
-# 로깅 설정
+from service.scraper import TimetableLoader
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# 상수 정의
-ALLOWED_URL_HOST = "everytime.kr"
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    try:
-        logger.info("브라우저 시작...")
-        browser_manager = await get_browser_manager()
-        await browser_manager.start_browser()
-        logger.info("애플리케이션 시작 완료")
-        yield
-    except Exception as e:
-        logger.error(f"애플리케이션 시작 오류: {e}")
-        raise
-    finally:
-        logger.info("애플리케이션 종료 중...")
-        await cleanup_browser_manager()
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
 
 app.add_middleware(
-    CORSMiddleware,
+    CORSMiddleware,  # type: ignore
     allow_origins=[
         "http://localhost:5173",
         "https://rhythmeet-be.yeonjae.kr",
@@ -46,42 +26,34 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-class TimetableResponse(BaseModel):
-    success: bool
-    message: str
-    data: Optional[dict] = None
 
 class HealthCheckResponse(BaseModel):
     status: str
     service: str
 
+
 @app.get("/health", response_model=HealthCheckResponse)
 def health_check():
     return {"status": "healthy", "service": "fastapi-scraper"}
 
+
 @app.get("/timetable")
 async def get_timetable(url: HttpUrl):
-    if url.host != ALLOWED_URL_HOST and not url.host.endswith("." + ALLOWED_URL_HOST):
+    if url.host != "everytime.kr" and not url.host.endswith("." + "everytime.kr"):
         raise HTTPException(status_code=400, detail="지정되지 않은 URL입니다.")
 
     try:
-        browser_manager = await get_browser_manager()
+        loader = TimetableLoader()
+        result = await loader.load_timetable(str(url))
 
-        if not browser_manager._is_started:
-            raise HTTPException(status_code=500, detail="브라우저가 초기화되지 않았습니다.")
+        if not result.get("success"):
+            error_message = result.get("message", "알 수 없는 오류")
+            status_code = 500 if "서버 오류" in error_message else 400
+            if "data" not in result:
+                result["data"] = {}
+            return JSONResponse(status_code=status_code, content=result)
 
-        async with browser_manager.get_page() as page:
-            loader = TimetableLoader()
-            result = await loader.load_timetable(str(url), page)
-
-            if not result.get("success"):
-                error_message = result.get("message", "알 수 없는 오류")
-                status_code = 500 if "서버 오류" in error_message else 400
-                if "data" not in result:
-                    result["data"] = {}
-                return JSONResponse(status_code=status_code, content=result)
-
-            return JSONResponse(status_code=200, content=result)
+        return JSONResponse(status_code=200, content=result)
 
     except Exception as e:
         logger.error(f"시간표 요청 중 오류: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn[standard]
-playwright
 pydantic
+httpx
+xmltodict


### PR DESCRIPTION
## **🛠️ PR 유형**

> 아래 항목 중 해당되는 것에 `[x]`로 체크해주세요. 해당되지 않는 항목은 그대로 두셔도 됩니다.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] application.properties, 의존성 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## **📌 작업 내용**

- 비동기 브라우저 관리 코드 제거하고 API 호출로 시간표 데이터 로딩 방식 변경
- XML 데이터 파싱 및 시간표 정보 추출 로직 추가
- Dockerfile에서 Playwright 관련 설치 명령어 제거
- API 직접 호출 방식으로 전환 관련 문서 업데이트

## **✅ 변경 사항**

- 자세한 사항은 문서를 참조할 것

## **📸 스크린샷 (선택)**

## **💬 코멘트**

- 개발자도구의 Network에서 해당 서비스의 API 흐름을 잘 분석하면 API 호출 방식을 활용할 수 있다는 꿀팁을 전수받아, PoC를 한 결과 성공적으로 받아올 수 있었다. 
- Playwright 켜서 하던 방식 대신 교체를 진행했다.
- 1-1.5초 가량의 스크래핑 응답시간은 0.1-0.5초로 단축되었다.